### PR TITLE
Add TMUX_AUTOEXIT flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The following environment variables control tmux.fish startup behavior:
 
 - **TMUX**: This variable is set by tmux itself when you are already inside a tmux session. tmux.fish checks this to avoid nesting tmux sessions.
 
+- **TMUX_AUTOEXIT**: If set to `true`, tmux.fish will automatically exit the current fish process after attaching to a tmux session. By default, it inherits the value of `TMUX_AUTOSTART` if not explicitly set. This is useful for ensuring that only the tmux session remains active in the terminal, preventing duplicate shells.
+
 
 You can set or unset these variables using the `set` command in fish, for example:
 

--- a/conf.d/tmux.fish
+++ b/conf.d/tmux.fish
@@ -33,4 +33,14 @@ if not tmux has-session -t "$tmux_session_name" 2>/dev/null
     tmux new-session -d -s "$tmux_session_name"
 end
 
-tmux attach-session -t "$tmux_session_name" 1>/dev/null && kill $fish_pid
+tmux attach-session -t "$tmux_session_name" 1>/dev/null
+
+# Set TMUX_AUTOEXIT to TMUX_AUTOSTART if not set
+if not set -q TMUX_AUTOEXIT
+    set -g TMUX_AUTOEXIT $TMUX_AUTOSTART
+end
+
+# Only kill the fish process if TMUX_AUTOEXIT is true
+if test "$TMUX_AUTOEXIT" = true
+    kill $fish_pid
+end

--- a/conf.d/tmux.fish
+++ b/conf.d/tmux.fish
@@ -35,7 +35,8 @@ end
 
 tmux attach-session -t "$tmux_session_name" 1>/dev/null
 
-# Set TMUX_AUTOEXIT to TMUX_AUTOSTART if not set
+# TMUX_AUTOEXIT controls whether the fish process should automatically exit after attaching to a tmux session.
+# If not set, it inherits the value of TMUX_AUTOSTART.
 if not set -q TMUX_AUTOEXIT
     set -g TMUX_AUTOEXIT $TMUX_AUTOSTART
 end


### PR DESCRIPTION
This adds a TMUX_AUTOEXIT

By default, auto exit happens, but it can be useful at times to leave the parent shell open instead of exiting it when tmux exits.
